### PR TITLE
following github's advise:

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -17,7 +17,7 @@ Collectfast==0.3.1
 
 # Email backends for Mailgun, Postmark, SendGrid and more
 # -------------------------------------------------------
-django-anymail==0.6.1
+django-anymail==1.2.1
 
 
 


### PR DESCRIPTION
webhooks/base.py in Anymail (aka django-anymail) before 1.2.1 is prone to a timing attack vulnerability on the WEBHOO...

production.txt update suggested:
django-anymail ~> 1.2.1